### PR TITLE
Add CJK fonts support and some minor fix

### DIFF
--- a/lib/font.coffee
+++ b/lib/font.coffee
@@ -70,13 +70,32 @@ class PDFFont
         @cmap = @ttf.cmap.unicode
         throw new Error 'No unicode cmap for font' if not @cmap
 
+        # CJK fonts support
+        @isCIDFont = @cmap.length >= 128
+
         @hmtx = @ttf.hmtx
-        @charWidths = (Math.round @hmtx.widths[gid] * @scaleFactor for i, gid of @cmap.codeMap when i >= 32)
+        @charWidths = {}
+        for i, gid of @cmap.codeMap
+          @charWidths[i] = Math.round @hmtx.widths[gid] * @scaleFactor
+          #console.log(i)
+        #@charWidths = ( @hmtx.widths[gid] * @scaleFactor for i, gid of @cmap.codeMap when i >= 32)
+        #@charWidths = (Math.round @hmtx.widths[gid] * @scaleFactor for i, gid of @cmap.codeMap when i >= 32)
+        #console.log(@scaleFactor)
+        
+        ### for i, j of @charWidths
+          console.log(i)
+          console.log(j)
+          console.log(typeof i)
+          console.log(typeof j)
+        console.log(@charWidths) # when i == 1000)
+        #console.log(typeof @hmtx.widths[gid] for i, gid of @cmap.codeMap)
+        console.log(@charWidths.length)
+        ###
         
         # Create a placeholder reference to be filled in embedTTF.
         @ref = @document.ref
             Type: 'Font'
-            Subtype: 'TrueType'
+            Subtype: if @isCIDFont then 'CIDFontType2' else 'TrueType'
             
     embedTTF: ->
         data = @subset.encode()
@@ -108,24 +127,51 @@ class PDFFont
             
         
         cmap = @document.ref()
-        cmap.add toUnicodeCmap(@subset.subset)
+        cmap.add toUnicodeCmap(@isCIDFont, if @isCIDFont then @subset.cmap else @subset.subset)
         cmap.finalize(true) # compress it
             
-        ref = 
-            Type: 'Font'
-            BaseFont: @subset.postscriptName
-            Subtype: 'TrueType'
-            FontDescriptor: @descriptor
-            FirstChar: firstChar
-            LastChar: firstChar + charWidths.length - 1
-            Widths: @document.ref charWidths
-            Encoding: 'MacRomanEncoding'
-            ToUnicode: cmap
+
+        ref = {}
+
+        if @isCIDFont
+            cIDSystemInfo = 
+                'Ordering': {isString: true, toString: -> 'Identity'}
+                'Registry': {isString: true, toString: -> 'Adobe'}
+                'Supplement': 0
+
+            descendantFont = @document.ref
+                BaseFont: @subset.postscriptName
+                CIDSystemInfo: cIDSystemInfo
+                Type: 'Font'
+                Subtype: 'CIDFontType2'
+                FontDescriptor: @descriptor
+                DW: 1000
+                CIDToGIDMap: 'Identity'
+
+            ref = 
+                DescendantFonts: [descendantFont]
+                Type: 'Font'
+                BaseFont: @subset.postscriptName
+                Subtype: 'Type0'
+                Encoding: 'Identity-H'
+                ToUnicode: cmap
+        
+        else
+            ref =
+                Type: 'Font'
+                BaseFont: @subset.postscriptName
+                Subtype: 'TrueType'
+                FontDescriptor: @descriptor
+                FirstChar: firstChar
+                LastChar: firstChar + charWidths.length - 1
+                Widths: @document.ref charWidths
+                Encoding: 'MacRomanEncoding'
+                ToUnicode: cmap
             
         for key, val of ref
             @ref.data[key] = val
             
-    toUnicodeCmap = (map) ->
+    toUnicodeCmap = (isCIDFont, map) ->
         unicodeMap = '''
             /CIDInit /ProcSet findresource begin
             12 dict begin
@@ -141,6 +187,22 @@ class PDFFont
             <00><ff>
             endcodespacerange
         '''
+        if isCIDFont
+            unicodeMap = '''
+                /CIDInit /ProcSet findresource begin
+                12 dict begin
+                begincmap
+                /CIDSystemInfo <<
+                  /Registry (TTX)
+                  /Ordering (TTX)
+                  /Supplement 0
+                >> def
+                /CMapName /TTX def
+                /CMapType 2 def
+                1 begincodespacerange
+                <0000><ffff>
+                endcodespacerange
+            '''
     
         codes = Object.keys(map).sort (a, b) -> a - b
         range = []
@@ -150,8 +212,14 @@ class PDFFont
                 range = []
                 
             unicode = ('0000' + map[code].toString(16)).slice(-4)
-            code = (+code).toString(16)
-            range.push "<#{code}><#{unicode}>"
+            if isCIDFont
+                code = +code;
+                cidcode = ('00' + (code >> 16).toString(16)).slice(-2)
+                cidcode += ('00' + (code & 255).toString(16)).slice(-2)
+                range.push "<#{cidcode}><#{cidcode}><#{unicode}>"
+            else
+                code = (+code).toString(16)
+                range.push "<#{code}><#{unicode}>"
             
         unicodeMap += "\n#{range.length} beginbfchar\n#{range.join('\n')}\nendbfchar\n" if range.length
         unicodeMap += '''
@@ -194,6 +262,7 @@ class PDFFont
         for i in [0...string.length]
             charCode = string.charCodeAt(i) - if @isAFM then 0 else 32
             width += @charWidths[charCode] or 0
+            #console.log("charCode #{charCode} , @charWidths[] #{@charWidths[charCode]}") if not @charWidths[charCode]
         
         scale = size / 1000    
         return width * scale

--- a/lib/font.coffee
+++ b/lib/font.coffee
@@ -97,9 +97,11 @@ class PDFFont
             
         @fontfile.add compressedData
                 
+        # Font names in PDF must not contain space character
+        fontName = @subset.postscriptName.replace(/\ /g, '_')
         @descriptor = @document.ref
             Type: 'FontDescriptor'
-            FontName: @subset.postscriptName
+            FontName: fontName
             FontFile2: @fontfile
             FontBBox: @bbox
             Flags: @flags
@@ -129,7 +131,7 @@ class PDFFont
                 'Supplement': 0
 
             descendantFont = @document.ref
-                BaseFont: @subset.postscriptName
+                BaseFont: fontName
                 CIDSystemInfo: cIDSystemInfo
                 Type: 'Font'
                 Subtype: 'CIDFontType2'
@@ -140,7 +142,7 @@ class PDFFont
             ref = 
                 DescendantFonts: [descendantFont]
                 Type: 'Font'
-                BaseFont: @subset.postscriptName
+                BaseFont: fontName
                 Subtype: 'Type0'
                 Encoding: 'Identity-H'
                 ToUnicode: cmap
@@ -148,7 +150,7 @@ class PDFFont
         else
             ref =
                 Type: 'Font'
-                BaseFont: @subset.postscriptName
+                BaseFont: fontName
                 Subtype: 'TrueType'
                 FontDescriptor: @descriptor
                 FirstChar: firstChar

--- a/lib/font.coffee
+++ b/lib/font.coffee
@@ -75,22 +75,11 @@ class PDFFont
 
         @hmtx = @ttf.hmtx
         @charWidths = {}
-        for i, gid of @cmap.codeMap
-          @charWidths[i] = Math.round @hmtx.widths[gid] * @scaleFactor
-          #console.log(i)
-        #@charWidths = ( @hmtx.widths[gid] * @scaleFactor for i, gid of @cmap.codeMap when i >= 32)
-        #@charWidths = (Math.round @hmtx.widths[gid] * @scaleFactor for i, gid of @cmap.codeMap when i >= 32)
-        #console.log(@scaleFactor)
-        
-        ### for i, j of @charWidths
-          console.log(i)
-          console.log(j)
-          console.log(typeof i)
-          console.log(typeof j)
-        console.log(@charWidths) # when i == 1000)
-        #console.log(typeof @hmtx.widths[gid] for i, gid of @cmap.codeMap)
-        console.log(@charWidths.length)
-        ###
+        if @isCIDFont
+            for i, gid of @cmap.codeMap
+              @charWidths[i] = Math.round @hmtx.widths[gid] * @scaleFactor
+        else
+            @charWidths = ( @hmtx.widths[gid] * @scaleFactor for i, gid of @cmap.codeMap when i >= 32)
         
         # Create a placeholder reference to be filled in embedTTF.
         @ref = @document.ref
@@ -259,10 +248,10 @@ class PDFFont
     widthOfString: (string, size) ->
         string = '' + string
         width = 0
+        minWidth=0
         for i in [0...string.length]
             charCode = string.charCodeAt(i) - if @isAFM then 0 else 32
             width += @charWidths[charCode] or 0
-            #console.log("charCode #{charCode} , @charWidths[] #{@charWidths[charCode]}") if not @charWidths[charCode]
         
         scale = size / 1000    
         return width * scale

--- a/lib/font/subset.coffee
+++ b/lib/font/subset.coffee
@@ -5,7 +5,9 @@ class Subset
     constructor: (@font) ->
         @subset = {}
         @unicodes = {}
-        @next = 33 # PDFs don't like character codes between 0 and 32
+        # CJK fonts support
+        @isCIDFont = @font.cmap.unicode.length >= 128
+        @next = if @isCIDFont then 1 else 33 # PDFs don't like character codes between 0 and 32 with simple font
         
     use: (character) ->
         # if given a string, add each character
@@ -25,7 +27,11 @@ class Subset
         string = ''
         for i in [0...text.length]
             char = @unicodes[text.charCodeAt(i)]
-            string += String.fromCharCode(char)
+            if @isCIDFont
+                string += String.fromCharCode(char >> 16)
+                string += String.fromCharCode(char & 255)
+            else
+                string += String.fromCharCode(char)
             
         return string
         


### PR DESCRIPTION
Hi devongovett,

I've been working on adding support of CJK fonts to pdfkit, originating from the issue #44.

CJK fonts are supported in PDF as Type0 composite fonts. 
So fonts containing more than 128 characters are consider composite fonts, while others are preserved the way they are now as already supported Type1 simple fonts.

Also, it seems that PDF don't like font names containing spaces, it is fixed as well.
