### PR TITLE
added bgImgPath option for automatically setting page background image

### DIFF
--- a/lib/document.coffee
+++ b/lib/document.coffee
@@ -97,8 +97,11 @@ class PDFDocument extends stream.Readable
     # flip PDF coordinate system so that the origin is in
     # the top left rather than the bottom left
     @_ctm = [1, 0, 0, 1, 0, 0]
-    @transform 1, 0, 0, -1, 0, @page.height
-    
+    @transform 1, 0, 0, -1, 0, @page.height	
+     
+    # add background image to page automatically if option is set
+    @image(@options.bgImgPath, 0, 0) if @options.bigImgPath
+
     return this
 
   bufferedPageRange: -> 


### PR DESCRIPTION
With this change, you can now pass an option 'bgImgPath' to PDFDocument and it will apply the background image to every new page that's created. This is especially needed when new pages are created for you automatically (when text exceeds page length and new page is created). 