### PR TITLE
Updated Docs to list support for a base64 data uri and buffer when adding an image

### DIFF
--- a/docs/images.coffee.md
+++ b/docs/images.coffee.md
@@ -21,7 +21,7 @@ Here is an example showing some of these options.
        .text('Proprotional to width', 0, 0)
      
     # Fit the image within the dimensions
-    doc.image('data:image/png;base64,iVBORw0K...', 320, 15, fit: [100, 100])
+    doc.image('images/test.jpeg', 320, 15, fit: [100, 100])
        .rect(320, 15, 100, 100)
        .stroke()
        .text('Fit', 320, 0)

--- a/docs/images.coffee.md
+++ b/docs/images.coffee.md
@@ -1,6 +1,6 @@
 # Images in PDFKit
 
-Adding images to PDFKit documents is an easy task. Just pass an image path to
+Adding images to PDFKit documents is an easy task. Just pass an image path, buffer, or data uri with base64 encoded data to
 the `image` method along with some optional arguments. PDFKit supports the
 JPEG and PNG formats. If an X and Y position are not provided, the image is
 rendered at the current point in the text flow (below the last line of text).
@@ -21,7 +21,7 @@ Here is an example showing some of these options.
        .text('Proprotional to width', 0, 0)
      
     # Fit the image within the dimensions
-    doc.image('images/test.jpeg', 320, 15, fit: [100, 100])
+    doc.image('data:image/png;base64,iVBORw0K...', 320, 15, fit: [100, 100])
        .rect(320, 15, 100, 100)
        .stroke()
        .text('Fit', 320, 0)


### PR DESCRIPTION
I noticed that pdfkit supports passing a data uri with base64 encoded data in addition to the image path when adding an image but this was not documented.