### PR TITLE
Fix missing object.coffee outputs.

### DIFF
--- a/lib/object.coffee
+++ b/lib/object.coffee
@@ -15,12 +15,9 @@ class PDFObject
         else if typeof object is 'string'
             '/' + object
 
-        else if object?.isString
-            '(' + object + ')'
-			
-		else if object?.isRaw
-			object.toString()
-            
+        else if Buffer.isBuffer(object)
+            object.toString()
+			            
         else if object instanceof PDFReference
             object.toString()
             
@@ -67,10 +64,7 @@ class PDFObject
         if swap
             string = swapBytes(new Buffer('\ufeff' + string, 'ucs-2')).toString('binary')
         
-        return {
-            isString: yes
-            toString: -> string
-        }
+        return new Buffer("("+string+")")
         
 module.exports = PDFObject
 PDFReference = require './reference'

--- a/lib/object.coffee
+++ b/lib/object.coffee
@@ -17,6 +17,9 @@ class PDFObject
 
         else if object?.isString
             '(' + object + ')'
+			
+		else if object?.isRaw
+			object.toString()
             
         else if object instanceof PDFReference
             object.toString()


### PR DESCRIPTION
I have been working on a "optional" loaded javascript file that will import a pdf into a new pdf for output.   Everything works other than pdfkit currently doesn't support outputting a "hex" value.   i.e \< 0A \>, the Object.convert wants to either treat it as a String key i.e. /0A   or as a Object \<\< 0A \>\>

