### PR TITLE
Implementing footer functionality

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -15,13 +15,14 @@ class LineWrapper extends EventEmitter
     @column    = 1
     @ellipsis  = options.ellipsis
     @continuedX  = 0
+    @footerStartY = @document.page.maxY() - @document.page.footerHeight
     
     # calculate the maximum Y position the text can appear at
     if options.height?
       @height = options.height
       @maxY = @startY + options.height
-    else
-      @maxY = @document.page.maxY()
+    else 
+      @maxY = @footerStartY
     
     # handle paragraph indents
     @on 'firstLine', (options) =>
@@ -216,7 +217,7 @@ class LineWrapper extends EventEmitter
       @document.addPage()
       @column = 1
       @startY = @document.page.margins.top
-      @maxY = @document.page.maxY()
+      @maxY = @footerStartY
       @document.x = @startX
       @document.fillColor @document._fillColor... if @document._fillColor
       @emit 'pageBreak', options, this

--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -140,6 +140,9 @@ module.exports =
       @x = x
     if y?
       @y = y
+      @maxY = @page.height - @page.margins.bottom
+    else
+      @maxY = @page.height - @page.margins.bottom - @page.footerHeight
 
     # wrap to margins if no x or y position passed
     unless options.lineBreak is false

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -20,6 +20,9 @@ class PDFPage
     else
       @margins = options.margins or DEFAULT_MARGINS
       
+    # prepare for footers
+    @footerHeight = options.footerHeight or 0 
+      
     # calculate page dimensions
     dimensions = if Array.isArray(@size) then @size else SIZES[@size.toUpperCase()]
     @width = dimensions[if @layout is 'portrait' then 0 else 1]


### PR DESCRIPTION
This pull request includes includes all the work which should implement footers in PDFKit. I understand that I need to change the docs but I thought I could open the pull request in order to ask for feedback about this. This feature works by adding a footerHeight property to options when creating the document. Then, all calls to text() which do not include coordinates are not allowed to obstruct the footer area. However, when coordinates are included, the footer area is not enforced, thus allowing anyone to write in it. 

Please if anyone has any feedback, tell me before I rebase this pull request and edit the docs. Thanks. 