### PR TITLE
Implement footer area functionality

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -21,7 +21,7 @@ class LineWrapper extends EventEmitter
       @height = options.height
       @maxY = @startY + options.height
     else
-      @maxY = @document.page.maxY()
+      @maxY = @document.page.maxY( options.yIsSpecified )
     
     # handle paragraph indents
     @on 'firstLine', (options) =>

--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -140,6 +140,11 @@ module.exports =
       @x = x
     if y?
       @y = y
+      @maxY = @page.maxY(true)
+      options.yIsSpecified = true
+    else
+      @maxY = @page.maxY(false)
+      options.yIsSpecified = false
 
     # wrap to margins if no x or y position passed
     unless options.lineBreak is false

--- a/lib/page.coffee
+++ b/lib/page.coffee
@@ -20,6 +20,9 @@ class PDFPage
     else
       @margins = options.margins or DEFAULT_MARGINS
       
+    # process footer
+    @footerHeight = options.footerHeight or 0
+      
     # calculate page dimensions
     dimensions = if Array.isArray(@size) then @size else SIZES[@size.toUpperCase()]
     @width = dimensions[if @layout is 'portrait' then 0 else 1]
@@ -52,8 +55,13 @@ class PDFPage
       Contents: @content
       Resources: @resources
       
-  maxY: ->
-    @height - @margins.bottom
+  maxY: (yIsSpecified) ->
+    # If a y-coordinate is included, text is allowed to be written to "footer"
+    if yIsSpecified
+      @height - @margins.bottom
+    # Else (no y-coordinate is included), the script needs to be avoid writing in "footer"
+    else
+      @height - @margins.bottom - @footerHeight
         
   write: (chunk) ->
     @content.write chunk


### PR DESCRIPTION
This is a redone version of the pull request I made in #397. This can close issue #388. I'll copy and paste the description in the pull request I made earlier. 

This pull request includes includes all the work which should implement footers in PDFKit. I understand that I need to change the docs but I thought I could open the pull request in order to ask for feedback about this. This feature works by adding a footerHeight property to options when creating the document. Then, all calls to text() which do not include coordinates are not allowed to obstruct the footer area. However, when coordinates are included, the footer area is not enforced, thus allowing anyone to write in it.

Please if anyone has any feedback, tell me before I edit the docs. Thanks.