### PR TITLE
fix PDF corruption when using lineBreak: false and underline:true (or strike: true)

### DIFF
--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -142,7 +142,9 @@ module.exports =
       @y = y
 
     # wrap to margins if no x or y position passed
-    unless options.lineBreak is false
+    if options.lineBreak is false
+      options.width = Number.MAX_SAFE_INTEGER
+    else
       margins = @page.margins
       options.width ?= @page.width - @x - margins.right
 


### PR DESCRIPTION
This patch addresses https://github.com/devongovett/pdfkit/issues/401

It fixes the bug by making sure the line drawn for the underline does not write out NaN by always using line_wrapper and just setting an arbitrarily large width.  This ensures options.textWidth gets set correctly which causes renderedWidth not get set to NaN which breaks the PDF.
