### PR TITLE
Fixing typo which make tests fail

### DIFF
--- a/lib/image/png.coffee
+++ b/lib/image/png.coffee
@@ -12,7 +12,7 @@ class PNGImage
   embed: (@document) ->
     return if @obj
     
-    @obj = document.ref
+    @obj = @document.ref
       Type: 'XObject'
       Subtype: 'Image'
       BitsPerComponent: @image.bits


### PR DESCRIPTION
Now fontkit branch should be functional. Without this patch you will have following:
```
ReferenceError: document is not defined
  at PNGImage.embed (/Users/ilovriakov/side/pdfkit/js/image/png.js:25:18)
  at PDFDocument.module.exports.image (/Users/ilovriakov/side/pdfkit/js/mixins/images.js:29:15)
  at Object.<anonymous> (/Users/ilovriakov/side/pdfkit/demo/test.coffee:22:5)
  at Object.<anonymous> (/Users/ilovriakov/side/pdfkit/demo/test.coffee:1:1)
  at Module._compile (module.js:460:26)
```