### PR TITLE
Path.coffee updated to fix SVG Path Arcs

### DIFF
--- a/lib/path.coffee
+++ b/lib/path.coffee
@@ -310,12 +310,12 @@ class SVGPath
 
     th_half = 0.5 * (th1 - th0)
     t = (8 / 3) * Math.sin(th_half * 0.5) * Math.sin(th_half * 0.5) / Math.sin(th_half)
-    x1 = cx + Math.cos(th0) - t * Math.sin(th0)
-    y1 = cy + Math.sin(th0) + t * Math.cos(th0)
-    x3 = cx + Math.cos(th1)
-    y3 = cy + Math.sin(th1)
-    x2 = x3 + t * Math.sin(th1)
-    y2 = y3 - t * Math.cos(th1)
+    x1 = fixRoundingError(cx + Math.cos(th0) - t * Math.sin(th0))
+    y1 = fixRoundingError(cy + Math.sin(th0) + t * Math.cos(th0))
+    x3 = fixRoundingError(cx + Math.cos(th1))
+    y3 = fixRoundingError(cy + Math.sin(th1))
+    x2 = fixRoundingError(x3 + t * Math.sin(th1))
+    y2 = fixRoundingError(y3 - t * Math.cos(th1))
 
     return [
       a00 * x1 + a01 * y1,   a10 * x1 + a11 * y1,
@@ -323,4 +323,9 @@ class SVGPath
       a00 * x3 + a01 * y3,   a10 * x3 + a11 * y3
     ]
 
+  fixRoundingError = (x) ->
+    if Math.abs(Math.round(x) - x) < 0.0000000000001
+      return Math.round(x);  
+    return x
+        
 module.exports = SVGPath


### PR DESCRIPTION
Fixed an issue which causes SVG path to fail when parsing an Arc.

When drawing SVG arcs, due to rounding errors in the Beizer Curve calculation, some of the outputs (x1,y1,x2,y2,x3,y3)  were within 1E-16 of an integer which cause the drawing of the Beizer curve to fail. By checking the precision and rounding to nearest integer the problem is fixed.

This also closes out issue #288.

The following path posted by StephanVD renders (example attached).
> M 100,100 L 100,0 A 100,100 0 0 1 175.44817868315766,165.6320983467258 Z

The following path posted by jaisor rendors with some minor amendments to fix the rounding errors in the source (example attached).
> M6.429183357567481e-15,-105A105,105 0 0,1 104.77516788447983,-6.867619294855041L74.83940563177131,-4.905442353467887A75,75 0 0,0 4.592273826833915e-15,-75Z

becomes

> M0,-105A105,105 0 0,1 104.77516788447983,-6.867619294855041L74.83940563177131,-4.905442353467887A75,75 0 0,0 0,-75Z

[ExampleFixes.pdf](https://github.com/devongovett/pdfkit/files/225789/ExampleFixes.pdf)
