### PR TITLE
fix(path): rounding issue on ops calculations

### DIFF
--- a/lib/path.coffee
+++ b/lib/path.coffee
@@ -92,17 +92,17 @@ class SVGPath
     # run the commands
     for c, i in commands
       runners[c.cmd]?(doc, c.args)
-      
+
     cx = cy = px = py = 0
 
-  runners = 
+  runners =
     M: (doc, a) ->
       cx = a[0]
       cy = a[1]
       px = py = null
       sx = cx
       sy = cy
-      doc.moveTo cx, cy
+      doc.moveTo(fixRoundingError(cx), fixRoundingError(cy))
 
     m: (doc, a) ->
       cx += a[0]
@@ -110,7 +110,10 @@ class SVGPath
       px = py = null
       sx = cx
       sy = cy
-      doc.moveTo cx, cy
+      doc.moveTo(
+        fixRoundingError(cx),
+        fixRoundingError(cy)
+      )
 
     C: (doc, a) ->
       cx = a[4]
@@ -120,7 +123,14 @@ class SVGPath
       doc.bezierCurveTo a...
 
     c: (doc, a) ->
-      doc.bezierCurveTo a[0] + cx, a[1] + cy, a[2] + cx, a[3] + cy, a[4] + cx, a[5] + cy
+      doc.bezierCurveTo(
+        fixRoundingError(a[0] + cx),
+        fixRoundingError(a[1] + cy),
+        fixRoundingError(a[2] + cx),
+        fixRoundingError(a[3] + cy),
+        fixRoundingError(a[4] + cx),
+        fixRoundingError(a[5] + cy)
+      )
       px = cx + a[2]
       py = cy + a[3]
       cx += a[4]
@@ -131,7 +141,11 @@ class SVGPath
         px = cx
         py = cy
 
-      doc.bezierCurveTo cx-(px-cx), cy-(py-cy), a[0], a[1], a[2], a[3]
+      doc.bezierCurveTo(
+        fixRoundingError(cx-(px-cx)),
+        fixRoundingError(cy-(py-cy)),
+        a[0], a[1], a[2], a[3]
+      )
       px = a[0]
       py = a[1]
       cx = a[2]
@@ -141,22 +155,34 @@ class SVGPath
       if px is null
         px = cx
         py = cy
-        
-      doc.bezierCurveTo cx-(px-cx), cy-(py-cy), cx + a[0], cy + a[1], cx + a[2], cy + a[3]
+
+      doc.bezierCurveTo(
+        fixRoundingError(cx-(px-cx)),
+        fixRoundingError(cy-(py-cy)),
+        fixRoundingError(cx + a[0]),
+        fixRoundingError(cy + a[1]),
+        fixRoundingError(cx + a[2]),
+        fixRoundingError(cy + a[3])
+      )
       px = cx + a[0]
       py = cy + a[1]
       cx += a[2]
       cy += a[3]
-      
+
     Q: (doc, a) ->
       px = a[0]
       py = a[1]
       cx = a[2]
       cy = a[3]
-      doc.quadraticCurveTo(a[0], a[1], cx, cy)
+      doc.quadraticCurveTo(a[0], a[1], fixRoundingError(cx), fixRoundingError(cy))
 
     q: (doc, a) ->
-      doc.quadraticCurveTo(a[0] + cx, a[1] + cy, a[2] + cx, a[3] + cy)
+      doc.quadraticCurveTo(
+        fixRoundingError(a[0] + cx),
+        fixRoundingError(a[1] + cy),
+        fixRoundingError(a[2] + cx),
+        fixRoundingError(a[3] + cy)
+      )
       px = cx + a[0]
       py = cy + a[1]
       cx += a[2]
@@ -166,11 +192,11 @@ class SVGPath
       if px is null
         px = cx
         py = cy
-      else 
+      else
         px = cx-(px-cx)
         py = cy-(py-cy)
 
-      doc.quadraticCurveTo(px, py, a[0], a[1])
+      doc.quadraticCurveTo(fixRoundingError(px), fixRoundingError(py), a[0], a[1])
       px = cx-(px-cx)
       py = cy-(py-cy)
       cx = a[0]
@@ -183,8 +209,12 @@ class SVGPath
       else
         px = cx-(px-cx)
         py = cy-(py-cy)
-
-      doc.quadraticCurveTo(px, py, cx + a[0], cy + a[1])
+      doc.quadraticCurveTo(
+        fixRoundingError(px),
+        fixRoundingError(py),
+        fixRoundingError(cx + a[0]),
+        fixRoundingError(cy + a[1])
+      )
       cx += a[0]
       cy += a[1]
 
@@ -204,33 +234,33 @@ class SVGPath
       cx = a[0]
       cy = a[1]
       px = py = null
-      doc.lineTo(cx, cy)
+      doc.lineTo(fixRoundingError(cx), fixRoundingError(cy))
 
     l: (doc, a) ->
       cx += a[0]
       cy += a[1]
       px = py = null
-      doc.lineTo(cx, cy)
+      doc.lineTo(fixRoundingError(cx), fixRoundingError(cy))
 
     H: (doc, a) ->
       cx = a[0]
       px = py = null
-      doc.lineTo(cx, cy)
+      doc.lineTo(fixRoundingError(cx), fixRoundingError(cy))
 
     h: (doc, a) ->
       cx += a[0]
       px = py = null
-      doc.lineTo(cx, cy)
+      doc.lineTo(fixRoundingError(cx), fixRoundingError(cy))
 
     V: (doc, a) ->
       cy = a[0]
       px = py = null
-      doc.lineTo(cx, cy)
+      doc.lineTo(fixRoundingError(cx), fixRoundingError(cy))
 
     v: (doc, a) ->
       cy += a[0]
       px = py = null
-      doc.lineTo(cx, cy)
+      doc.lineTo(fixRoundingError(cx), fixRoundingError(cy))
 
     Z: (doc) ->
       doc.closePath()


### PR DESCRIPTION
I encountered a lot of rounding issues when passing different svg paths that result to the corruption of the PDFs (just like #492).

Some examples:

```
M10.157933993602363,-0.8611397330216536q0,0.3690598855807087,-0.2811884842519685,0.6502483698326772t-0.6678226500984252,0.2811884842519685h-8.277486005167324q-0.40420844611220474,0,-0.6678226500984252,-0.2636142039862205t-0.2636142039862205,-0.6678226500984252v-3.3215389702263782q0,-0.4217827263779528,0.2636142039862205,-0.6678226500984252t0.6678226500984252,-0.2636142039862205h8.277486005167324q0.40420844611220474,-0.017574280265748032,0.6678226500984252,0.2636142039862205t0.2811884842519685,0.6678226500984252v3.3215389702263782z
```

```
M4.159304910494586,-7.216350962721456q-1.2486526128813975,0,-2.144237935223917,0.8955853223425196t-0.8869739250123031,2.1356265378937005q0,1.257264010211614,0.8869739250123031,2.152849332554134q0.8783625276820866,0.8955853223425196,2.1356265378937005,0.8955853223425196t2.152849332554134,-0.8955853223425196t0.9128081170029526,-2.144237935223917q0,-1.2486526128813975,-0.9041967196727361,-2.144237935223917t-2.152849332554134,-0.8955853223425196zM4.167916307824803,0q-1.722279466043307,0,-2.9450978869340547,-1.222818420890748t-1.222818420890748,-2.9364864896038383t1.2142070235605313,-2.9450978869340547t2.962320681594488,-1.2314298182209644t2.927875092273622,1.2142070235605313q1.2314298182209644,1.2314298182209644,1.2314298182209644,2.953709284264271t-1.222818420890748,2.9450978869340547t-2.9450978869340547,1.222818420890748z
```
