### PR TITLE
Add support for dash array

### DIFF
--- a/lib/mixins/vector.coffee
+++ b/lib/mixins/vector.coffee
@@ -46,11 +46,14 @@ module.exports =
     
   dash: (length, options = {}) ->
     return this unless length?
-    
-    space = options.space ? length
-    phase = options.phase or 0
-    
-    @addContent "[#{length} #{space}] #{phase} d"
+    if Array.isArray length
+      length = length.join ' '
+      phase = options.phase or 0
+      @addContent "[#{length}] #{phase} d"
+    else
+      space = options.space ? length
+      phase = options.phase or 0
+      @addContent "[#{length} #{space}] #{phase} d"
     
   undash: ->
     @addContent "[] 0 d"


### PR DESCRIPTION
The PDF reference allows complex dash patterns. The 1st argument of the `dash` function can now be an array.

![image](https://cloud.githubusercontent.com/assets/17966696/18751835/2856670e-80e9-11e6-9127-836774d6e543.png)
