### PR TITLE
Changed polygon method in Vector.coffee to accept an array of points …

### DIFF
--- a/lib/mixins/vector.coffee
+++ b/lib/mixins/vector.coffee
@@ -107,8 +107,15 @@ module.exports =
     
   circle: (x, y, radius) ->
     @ellipse x, y, radius
-    
-  polygon: (points...) ->
+  
+  #PATCH - Jorge Lopez
+  # Changed argument for polygon method
+  #used to take in a splat
+  # Now accepts an array of points. ie. [[x, y]]
+  polygon : (points) ->
+    if not points or points.length < 1
+      return false
+
     @moveTo points.shift()...
     @lineTo point... for point in points
     @closePath()


### PR DESCRIPTION
…instead of a splat.
## Change the polygon method in Vector.coffee to accept an array of points instead of points passed in manually as a splat.
##### I exported a svg file from Illustrator that contained a polygon with the below data (as a string).

``` javascript
'4.473,84.225 75.847,84.225 81.847,79.225 87.847,84.225 160.517,84.225 160.528,5.377 157.374,7.073 154.222,5.377 151.069,7.073 147.919,5.377 144.767,7.073 141.614,5.377 138.463,7.073 135.312,5.377 132.161,7.073 129.013,5.377 125.862,7.073 122.715,5.377 119.563,7.073 116.418,5.377 113.272,7.073 110.126,5.377 106.976,7.073 103.828,5.377 100.679,7.073 97.529,5.377 94.38,7.073 91.229,5.377 88.083,7.073 84.935,5.377 81.785,7.073 78.638,5.377 75.49,7.073 72.34,5.377 69.192,7.073 66.046,5.377 62.9,7.073 59.751,5.377 56.604,7.073 53.456,5.377 50.311,7.073 47.166,5.377 44.02,7.073 40.871,5.377 37.723,7.073 34.578,5.377 31.434,7.073 28.289,5.377 25.145,7.073 22,5.377 18.854,7.073 15.705,5.377 12.559,7.073 9.415,5.377 6.271,7.073 4.471,6.102 '
```
##### It seems that the polygon method only takes points passed in manually. E.g. `polygon([1,2], [4,2])`. i needed to break up the SVG string into an array and pass it to the polygon method.
##### I wrote this function to convert the string polygon points to an array of points. The array is in the format: `[ [x,y], [x, y], [x, y] ]`.

``` javascript
// converts a svg polygon's points to an array.
function polygonPointsToArray(points){

    var pointsArray = [];

    // pattern to breakup points by the space followed by a number or a decimal
    var pattern = /\s(?=\d+\.?\d*|\.\d+)/g;

    // break up each pair by the separating space
    points.split(pattern).forEach(function(value, index, arr){

        // break up the value by the separating comma
        var point = value.split(',');
        pointsArray.push([parseFloat(point[0]), parseFloat(point[1])]);
    });

    return pointsArray;
}
```
##### Now I passed the array of points (`[ [x,y], [x, y], [x, y] ]` to the polygon method. This allows the the polygon method to accept points dynamically.
##### This is the modified polygon method in coffeescript.

``` coffescript
  #PATCH - Jorge Lopez
  # Changed argument for polygon method
  #used to take in a splat
  # Now accepts an array of points. ie. [[x, y]]

  polygon : (points) ->
    if not points or points.length < 1
      return false

    @moveTo points.shift()...
    @lineTo point... for point in points
    @closePath()
```
##### Produces js

``` javascript
    polygon: function(points) {
      var i, len, point;
      if (!points || points.length < 1) {
        return false;
      }
      this.moveTo.apply(this, points.shift());
      for (i = 0, len = points.length; i < len; i++) {
        point = points[i];
        this.lineTo.apply(this, point);
      }
      return this.closePath();
    }
```
