### PR TITLE
allow setting size of list bullet circle via options

### DIFF
--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -70,7 +70,8 @@ module.exports =
   list: (list, x, y, options, wrapper) ->
     options = @_initOptions(x, y, options)
     
-    r = Math.round (@_font.ascender / 1000 * @_fontSize) / 3
+    midLine = Math.round (@_font.ascender / 1000 * @_fontSize) / 2
+    r = options.bulletRadius or Math.round (@_font.ascender / 1000 * @_fontSize) / 3
     indent = options.textIndent or r * 5
     itemIndent = options.bulletIndent or r * 8
     
@@ -102,7 +103,7 @@ module.exports =
         wrapper.lineWidth -= diff
         level = l
         
-      @circle @x - indent + r, @y + r + (r / 2), r
+      @circle @x - indent + r, @y + midLine, r
       @fill()
         
     wrapper.on 'sectionStart', =>


### PR DESCRIPTION
this change will allow users to set the size of the circle on bullet list item in the options via the setting "bulletRadius"

usage: 

```
doc.list(["item1", "item2", "item3"], x, y, { bulletRadius: 2 });
```

without setting bulletRadius, it will default to the size as it was before.
