### PR TITLE
Fix paper sizes link

### DIFF
--- a/docs/getting_started.coffee.md
+++ b/docs/getting_started.coffee.md
@@ -95,7 +95,7 @@ You can also set some options for the page, such as it's size and orientation.
 The `layout` property can be either `portrait` (the default) or `landscape`.
 The `size` property can be either an array specifying `[width, height]` in PDF
 points (72 per inch), or a string specifying a predefined size. A
-list of the predefined paper sizes can be seen [here](http://pdfkit.org/docs/paper_sizes.html). The
+list of the predefined paper sizes can be seen [here](https://github.com/devongovett/pdfkit/blob/b13423bf0a391ed1c33a2e277bc06c00cabd6bf9/lib/page.coffee#L72-L122). The
 default is `letter`.
 
 Passing a page options object to the `PDFDocument` constructor will


### PR DESCRIPTION
I couldn't find a doc with page sizes, so I'm just linking to the code.

I submitted this to the gh-pages branch instead of master in https://github.com/devongovett/pdfkit/pull/567.

📄
