### PR TITLE
Line wrapper bug

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -156,9 +156,9 @@ class LineWrapper extends EventEmitter
           buffer = buffer + @ellipsis
           
         if bk.required and w > @spaceLeft
-          buffer = word;
-          textWidth = w;
-          wc = 1;
+          buffer = word
+          textWidth = w
+          wc = 1
 
         emitLine()
         

--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -155,6 +155,11 @@ class LineWrapper extends EventEmitter
         
           buffer = buffer + @ellipsis
           
+        if bk.required and w > @spaceLeft
+          buffer = word;
+          textWidth = w;
+          wc = 1;
+
         emitLine()
         
         # if we've reached the edge of the page, 
@@ -170,13 +175,6 @@ class LineWrapper extends EventEmitter
         
         # reset the space left and buffer
         if bk.required
-          # if there's a word but no space left, emit single line
-          if w > @spaceLeft
-            buffer = word
-            textWidth = w
-            wc = 1
-            emitLine()
-            
           @spaceLeft = @lineWidth
           buffer = ''
           textWidth = 0


### PR DESCRIPTION
fix #345
The problem was the function emitLine() being called twice if the last line contained only one word, at lines 158 and 178.
There can be some side-effects because I don't understand completely how the code works!