### PR TITLE
Fix transform property for gradients with opacity

### DIFF
--- a/lib/gradient.coffee
+++ b/lib/gradient.coffee
@@ -103,7 +103,7 @@ class PDFGradient
         Type: 'XObject'
         Subtype: 'Form'
         FormType: 1
-        BBox: [0, 0, @doc.page.width, @doc.page.height]
+        BBox: [-1000000, -1000000, 1000000, 1000000]
         Group: group
         Resources: resources
       

--- a/lib/gradient.coffee
+++ b/lib/gradient.coffee
@@ -107,6 +107,7 @@ class PDFGradient
         Group: group
         Resources: resources
       
+      form.write "#{@transform.join(" ")} cm"
       form.end "/Sh1 sh"
       
       sMask = @doc.ref


### PR DESCRIPTION
I see there is a transform property in the PDFGradient objects. It works fine for opaque gradients, however for gradients with transparency, the color and the transparency get misaligned.

(The examples below can easily be achieved without the transform property, but with more complex shapes and/or transform matrices that would be difficult)

```
var doc = new PDFDocument({compress:false});

doc.translate(50,50);

var grad = doc.linearGradient(0,0,200,0);
    grad.stop(0,'green', 1);
    grad.stop(0.4,'red', 0);
    grad.stop(0.5,'red', 1);
    grad.stop(0.6,'red', 0);
    grad.stop(1,'green', 1);
    grad.transform = [2, 0, 0, 1, 0, 0];
doc.roundedRect(0,0,400,200)
   .fill(grad);

doc.translate(0,250);

var radial = doc.radialGradient(100,100,0,100,100,100);
    radial.stop(0,'green', 1);
    radial.stop(0.4,'blue', 0);
    radial.stop(0.5,'blue', 1);
    radial.stop(0.6,'blue', 0);
    radial.stop(1,'green', 1);
    radial.transform = [2, 0, 0, 1, 0, 0];
doc.ellipse(200,100,200,100)
   .fill(radial);
```

[buggy.pdf](https://github.com/devongovett/pdfkit/files/607871/buggy.pdf)
[fixed.pdf](https://github.com/devongovett/pdfkit/files/607870/fixed.pdf)
