### PR TITLE
Fix scale function

### DIFF
--- a/lib/mixins/vector.coffee
+++ b/lib/mixins/vector.coffee
@@ -191,9 +191,9 @@ module.exports =
     @transform cos, sin, -sin, cos, x, y
 
   scale: (xFactor, yFactor = xFactor, options = {}) ->
-    if arguments.length is 2
-      yFactor = xFactor
+    if typeof yFactor is "object"
       options = yFactor
+      yFactor = xFactor
 
     x = y = 0
     if options.origin?


### PR DESCRIPTION
The function wasn't working in these cases:
`scale(xFactor, yFactor)`
`scale(xyFactor, options)`



Fix #598 