### PR TITLE
Fix incorrect escape of special characters when using UTF-16

### DIFF
--- a/lib/object.coffee
+++ b/lib/object.coffee
@@ -38,10 +38,7 @@ class PDFObject
 
     # String objects are converted to PDF strings (UTF-16)
     else if object instanceof String
-      # Escape characters as required by the spec
-      string = object.replace escapableRe, (c) ->
-        return escapable[c]
-
+      string = object
       # Detect if this is a unicode string
       isUnicode = false
       for i in [0...string.length] by 1
@@ -52,6 +49,10 @@ class PDFObject
       # If so, encode it as big endian UTF-16
       if isUnicode
         string = swapBytes(new Buffer('\ufeff' + string, 'utf16le')).toString('binary')
+
+      # Escape characters as required by the spec
+      string = string.replace escapableRe, (c) ->
+        return escapable[c]
 
       '(' + string + ')'
 


### PR DESCRIPTION
When using UTF-16 for encoding strings, specail characters should be escaped directly in UTF-16 encoded string. Pdf format doesn't expect escape by 2 bytes characters.

Code example:
```javascript
var PdfDoc = require("pdfkit");
var fs = require("fs");

var pdf = new PdfDoc({
    size: "A4",
    margin: 14
});

pdf.info["Title"] = "Test title (ä)";

pdf.pipe(fs.createWriteStream("test.pdf"));

pdf.end();
```
Current version of code will create next metadata: `/Title (юя T e s t   t i t l e   \ ( д \ ))`
This is ` \ (` not escaped bracket will broke pdf info.
Metadata should be like this: `/Title (юя T e s t   t i t l e   \( д \))`

So I propose to change order of encoding and escaping.