### PR TITLE
print empty string instead of undefined or null

### DIFF
--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -23,7 +23,7 @@ module.exports =
     options = @_initOptions(x, y, options)
 
     # Convert text to a string
-    text = '' + text
+    text = if text == null or text == undefined then '' else '' + text
 
     # if the wordSpacing option is specified, remove multiple consecutive spaces
     if options.wordSpacing

--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -23,7 +23,7 @@ module.exports =
     options = @_initOptions(x, y, options)
 
     # Convert text to a string
-    text = if text == null or text == undefined then '' else '' + text
+    text = if not text? then '' else '' + text
 
     # if the wordSpacing option is specified, remove multiple consecutive spaces
     if options.wordSpacing


### PR DESCRIPTION
writing `undefined` or `null` to a document is hardly the user's intention, so this fixes it