### PR TITLE
Add support for link to another page

### DIFF
--- a/lib/mixins/annotations.coffee
+++ b/lib/mixins/annotations.coffee
@@ -27,13 +27,25 @@ module.exports =
     
   link: (x, y, w, h, url, options = {}) ->
     options.Subtype = 'Link'
-    options.A = @ref
-      S: 'URI'
-      URI: new String url
-      
+
+    if typeof url is 'number'
+      # Link to a page in the document (the page must already exist)
+      pages = @_root.data.Pages.data
+      if url >= 0 and url < pages.Kids.length
+        options.A = @ref
+          S: 'GoTo'
+          D: [pages.Kids[url], 'XYZ', null, null, null]
+      else
+        throw new Error "The document has no page #{url}"
+    else
+      # Link to an external url
+      options.A = @ref
+        S: 'URI'
+        URI: new String url
+
     options.A.end()
     @annotate x, y, w, h, options
-    
+
   _markup: (x, y, w, h, options = {}) ->
     [x1, y1, x2, y2] = @_convertRect x, y, w, h
     options.QuadPoints = [x1, y2, x2, y2, x1, y1, x2, y1]

--- a/lib/mixins/annotations.coffee
+++ b/lib/mixins/annotations.coffee
@@ -35,15 +35,17 @@ module.exports =
         options.A = @ref
           S: 'GoTo'
           D: [pages.Kids[url], 'XYZ', null, null, null]
+        options.A.end()
       else
         throw new Error "The document has no page #{url}"
+
     else
       # Link to an external url
       options.A = @ref
         S: 'URI'
         URI: new String url
+      options.A.end()
 
-    options.A.end()
     @annotate x, y, w, h, options
 
   _markup: (x, y, w, h, options = {}) ->

--- a/lib/mixins/text.coffee
+++ b/lib/mixins/text.coffee
@@ -191,7 +191,7 @@ module.exports =
     renderedWidth = options.textWidth + (wordSpacing * (options.wordCount - 1)) + (characterSpacing * (text.length - 1))
 
     # create link annotations if the link option is given
-    if options.link
+    if options.link?
       @link x, y, renderedWidth, @currentLineHeight(), options.link
 
     # create underline or strikethrough line


### PR DESCRIPTION
```
doc.link(x, y, width, height, pageNumber)
doc.text(text, x, y, {link: pageNumber})
```
Fix #700 fix #467