### PR TITLE
Fixed line_wrapper.coffee: potential endless loop

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -74,7 +74,7 @@ class LineWrapper extends EventEmitter
         while word.length
           # fit as much of the word as possible into the space we have
           l = word.length
-          while w > @spaceLeft
+          while w > @spaceLeft and l > 0
             w = @wordWidth word.slice(0, --l)
             
           # send a required break unless this is the last piece


### PR DESCRIPTION
while w > @spaceLeft
            w = @wordWidth word.slice(0, --l) 
runs endless, if space is to tight for even a single character. Changed it to:
while w > @spaceLeft and l > 0
            w = @wordWidth word.slice(0, --l)