### PR TITLE
Fix linewrapper ellipsis inifinite loop

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -146,12 +146,16 @@ class LineWrapper extends EventEmitter
           textWidth = @wordWidth buffer + @ellipsis
           
           # remove characters from the buffer until the ellipsis fits
-          while textWidth > @lineWidth
+          # to avoid inifinite loop need to stop while-loop if buffer is empty string
+          while buffer and textWidth > @lineWidth
             buffer = buffer.slice(0, -1).replace(/\s+$/, '')
             textWidth = @wordWidth buffer + @ellipsis
-        
-          buffer = buffer + @ellipsis
-          
+          # need to add ellipsis only if there is enough space for it
+          if textWidth <= @lineWidth
+            buffer = buffer + @ellipsis
+
+          textWidth = @wordWidth buffer
+
         if bk.required
           if w > @spaceLeft
             emitLine()


### PR DESCRIPTION
# Problem
If linewidth in linewrapper is too small even for just ellipsis, the while-loop starts and never ends

# Solution
Do while-loop till buffer is not empty string. After while-loop check if there is enough space to contain buffer and ellipsis, and only if this condition is true, add ellipsis to buffer