### PR TITLE
Long running loop fix

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -74,13 +74,15 @@ class LineWrapper extends EventEmitter
         while word.length
           # fit as much of the word as possible into the space we have
           if w > @spaceLeft
-            # start checking our text at the end of our remaining space - this works around long loops when processing massive text
+            # start our check at the end of our available space - this method is faster than a loop of each character and it resolves
+            # an issue with long loops when processing massive words, such as a huge number of spaces
             l = Math.ceil(@spaceLeft / (w / word.length))
             w = @wordWidth word.slice(0, l)
             mightGrow = w <= @spaceLeft and l < word.length
           else
             l = word.length
           mustShrink = w > @spaceLeft and l > 0
+          # shrink or grow word as necessary after our near-guess above
           while mustShrink or mightGrow
             if mustShrink
               w = @wordWidth word.slice(0, --l)


### PR DESCRIPTION
This is a speed enhancement to the word wrapping algorithm.  In the case of massive words, such as in the case of a huge number of spaces, this reduces the time from effectively infinite to near-instant.  In short, we make an educated guess as to how much space we have so that we start very close to the correct slice of the word, then we tweak as necessary by shrinking or growing our slice range.

Thanks to @mgetz for getting the core changes in place!