### PR TITLE
Fix bug with \n translation

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -77,8 +77,8 @@ class LineWrapper extends EventEmitter
           while w > @spaceLeft and l > 0
             w = @wordWidth word.slice(0, --l)
             
-          # send a required break unless this is the last piece
-          fbk.required = l < word.length
+          # send a required break unless this is the last piece and a linebreak is not specified
+          fbk.required = bk.required or l < word.length
           shouldContinue = fn word.slice(0, l), w, fbk, lbk
           lbk = required: false
           


### PR DESCRIPTION
This causes \n characters to be displayed more consistently by passing on required breaks when they are needed.  Before this change, text in the form of "alpha\nbeta\ngamma" could be translated incorrectly in some instances, in the form of:

"alphabeta
gamma"

The expected output, which this change brings about, is:

"alpha
beta
gamma"