### PR TITLE
Allows the text continue feature to work when the starting string is empty

### DIFF
--- a/lib/line_wrapper.coffee
+++ b/lib/line_wrapper.coffee
@@ -200,7 +200,7 @@ class LineWrapper extends EventEmitter
     # the y position
     if options.continued is yes
       @continuedX = 0 if lc > 1
-      @continuedX += options.textWidth
+      @continuedX += options.textWidth or 0
       @document.y = y
     else
       @document.x = @startX


### PR DESCRIPTION
Allows for the following case where the startFieldValue is empty and has no width.
```
startFieldValue = ''
lorem = 'Lorem ipsum'
endFieldValue = '..The End'

doc.text startFieldValue,  
  width: 465
  align: 'justify'
  continued: yes
 
doc.text lorem,
     width: 465
     continued: yes
   .text endFieldValue
```